### PR TITLE
Implement Swagger UI documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ axum = "0.7.9"
 serde = { version = "1.0.215", features = ["derive"] }
 tokio = { version = "1.41.1", features = ["full"] }
 uuid = { version = "1.11.0", features = ["v7", "v4"] }
+utoipa = { version = "3", features = ["axum_extras", "uuid"] }
+utoipa-swagger-ui = "9.0.2"
+serde_json = "1"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,22 @@
+# API Reference
+
+The API provides endpoints to manage users, groups and their associations. Business rules are documented in the Swagger UI available at `/swagger` when running the application.
+
+## Users
+- `POST /users` &mdash; Creates a user after validating name and email.
+- `GET /users/{id}` &mdash; Retrieves a single user.
+- `GET /users/all` &mdash; Lists all users.
+
+## Groups
+- `POST /groups` &mdash; Creates a group with a name and description.
+- `GET /groups/{id}` &mdash; Fetches a group by id.
+- `GET /groups/all` &mdash; Lists all groups.
+
+## User Groups
+- `POST /user-groups` &mdash; Links a user to a group, ensuring both exist.
+- `GET /user-groups/{id}` &mdash; Gets a specific user-group relation.
+- `GET /user-groups/user/{user_id}` &mdash; Lists groups for a user.
+- `GET /user-groups/group/{group_id}` &mdash; Lists users of a group.
+- `GET /user-groups/all` &mdash; Lists all relations.
+
+Return to the [index](index.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,15 @@
+# Getting Started
+
+Follow these steps to run the project locally:
+
+1. Install [Rust](https://www.rust-lang.org/tools/install) and Cargo.
+2. Clone the repository and navigate to its directory.
+3. Run the application:
+
+```bash
+cargo run
+```
+
+The API will be available at `http://localhost:3000`.
+
+Return to the [index](index.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# RsFlow Documentation
+
+Welcome to the RsFlow project! This site contains guides and references for developing and using the application.
+
+- [Getting Started](getting-started.md)
+- [API Reference](api-reference.md)
+
+For more information about the project itself, see the [README](../README.md).

--- a/src/adapters/controllers/group_controller.rs
+++ b/src/adapters/controllers/group_controller.rs
@@ -1,13 +1,14 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use crate::core::models::group_model::Group;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct CreateGroupRequest {
     pub name: String,
     pub description: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub struct GroupResponse {
     pub id: String,
     pub name: String,

--- a/src/adapters/controllers/user_controller.rs
+++ b/src/adapters/controllers/user_controller.rs
@@ -1,13 +1,14 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use crate::core::models::user_model::User;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct CreateUserRequest {
     pub name: String,
     pub email: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub struct UserResponse {
     pub id: String,
     pub name: String,

--- a/src/adapters/controllers/user_group_controller.rs
+++ b/src/adapters/controllers/user_group_controller.rs
@@ -1,15 +1,18 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use serde_json::json;
 use crate::core::models::user_group_model::UserGroup;
 // use crate::core::models::user_model::UserId;
 // use crate::core::models::group_model::GroupId;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct CreateUserGroupRequest {
     pub user_id: String,
     pub group_id: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
+#[schema(example = json!({"id":"f0000000-0000-0000-0000-000000000000","user_id":"11111111-1111-1111-1111-111111111111","group_id":"22222222-2222-2222-2222-222222222222"}))]
 pub struct UserGroupResponse {
     pub id: String,
     pub user_id: String,

--- a/src/infrastructure/api/routes/group_routes.rs
+++ b/src/infrastructure/api/routes/group_routes.rs
@@ -6,6 +6,7 @@ use axum::{
     Router
 };
 use std::sync::Arc;
+use utoipa::path;
 
 use crate::adapters::controllers::group_controller::{CreateGroupRequest, GroupResponse};
 use crate::core::services::group_service::GroupService;
@@ -23,6 +24,18 @@ pub fn build_routes(service: Arc<GroupService>) -> Router {
 
 
 // Controller functions
+#[utoipa::path(
+    post,
+    path = "/groups",
+    request_body = CreateGroupRequest,
+    responses(
+        (status = 201, description = "Grupo criado", body = GroupResponse),
+        (status = 400, description = "Falha na validação")
+    ),
+    tag = "Groups",
+    summary = "Criar grupo",
+    description = "Valida que nome e descrição não estejam vazios"
+)]
 pub async fn create_group(
     State(service): State<Arc<GroupService>>,
     Json(payload): Json<CreateGroupRequest>,
@@ -34,6 +47,18 @@ pub async fn create_group(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/groups/{id}",
+    params(("id" = String, Path, description = "Identificador do grupo")),
+    responses(
+        (status = 200, description = "Grupo encontrado", body = GroupResponse),
+        (status = 404, description = "Grupo não encontrado")
+    ),
+    tag = "Groups",
+    summary = "Buscar grupo por id",
+    description = "Retorna grupo se encontrado"
+)]
 pub async fn get_group_by_id(
     State(service): State<Arc<GroupService>>,
     Path(id): Path<String>,
@@ -43,6 +68,16 @@ pub async fn get_group_by_id(
 }
 
 
+#[utoipa::path(
+    get,
+    path = "/groups/all",
+    responses(
+        (status = 200, description = "Lista todos os grupos", body = [GroupResponse])
+    ),
+    tag = "Groups",
+    summary = "Listar grupos",
+    description = "Retorna todos os grupos cadastrados"
+)]
 pub async fn get_all_groups(State(service): State<Arc<GroupService>>) -> Result<Json<Vec<GroupResponse>>, String> {
     let groups = service.get_all_groups().map_err(|e| e.to_string())?;
     Ok(Json(groups.into_iter().map(GroupResponse::from).collect()))

--- a/src/infrastructure/api/routes/mod.rs
+++ b/src/infrastructure/api/routes/mod.rs
@@ -5,15 +5,55 @@ pub mod user_group_routers;
 
 use axum::response::IntoResponse;
 use axum::Router;
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
 use std::sync::Arc;
 use crate::core::interfaces::database::DatabaseError;
 use crate::core::services::group_service::GroupService;
 use crate::core::services::user_service::UserService;
 use crate::core::services::user_group_service::UserGroupService;
+use crate::adapters::controllers::user_controller::{CreateUserRequest, UserResponse};
+use crate::adapters::controllers::group_controller::{CreateGroupRequest, GroupResponse};
+use crate::adapters::controllers::user_group_controller::{CreateUserGroupRequest, UserGroupResponse};
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        user_routes::create_user,
+        user_routes::get_user_by_id,
+        user_routes::get_all_users,
+        group_routes::create_group,
+        group_routes::get_group_by_id,
+        group_routes::get_all_groups,
+        user_group_routers::create_user_group,
+        user_group_routers::get_user_group_by_id,
+        user_group_routers::get_user_group_by_user_id,
+        user_group_routers::get_user_group_by_group_id,
+        user_group_routers::get_all_user_groups,
+    ),
+    components(
+        schemas(
+            CreateUserRequest,
+            UserResponse,
+            CreateGroupRequest,
+            GroupResponse,
+            CreateUserGroupRequest,
+            UserGroupResponse,
+        )
+    ),
+    tags(
+        (name = "Users", description = "Operações relacionadas a usuários"),
+        (name = "Groups", description = "Operações relacionadas a grupos"),
+        (name = "UserGroups", description = "Associações entre usuários e grupos")
+    )
+)]
+pub struct ApiDoc;
 
 
-pub fn build_routes(user: Arc<UserService>, group: Arc<GroupService>, user_group: Arc<UserGroupService>) -> Router {    
+pub fn build_routes(user: Arc<UserService>, group: Arc<GroupService>, user_group: Arc<UserGroupService>) -> Router {
+    let openapi = ApiDoc::openapi();
     Router::new()
+        .merge(SwaggerUi::new("/swagger").url("/api-doc/openapi.json", openapi))
         .nest("/users", user_routes::build_routes(user))
         .nest("/groups", group_routes::build_routes(group))
         .nest("/user-groups", user_group_routers::build_routes(user_group))

--- a/src/infrastructure/api/routes/user_group_routers.rs
+++ b/src/infrastructure/api/routes/user_group_routers.rs
@@ -6,6 +6,9 @@ use axum::{
     Router
 };
 use std::sync::Arc;
+use utoipa::path;
+use serde_json::json;
+use utoipa::path;
 
 use crate::adapters::controllers::user_group_controller::{CreateUserGroupRequest, UserGroupResponse};
 use crate::core::services::user_group_service::UserGroupService;
@@ -26,6 +29,18 @@ pub fn build_routes(service: Arc<UserGroupService>) -> Router {
 
 
 // Controller functions
+#[utoipa::path(
+    post,
+    path = "/user-groups",
+    request_body = CreateUserGroupRequest,
+    responses(
+        (status = 201, description = "Associação criada", body = UserGroupResponse, example = json!({"id":"f0000000-0000-0000-0000-000000000000","user_id":"11111111-1111-1111-1111-111111111111","group_id":"22222222-2222-2222-2222-222222222222"})),
+        (status = 400, description = "Usuário ou grupo inexistente")
+    ),
+    tag = "UserGroups",
+    summary = "Criar associação usuário-grupo",
+    description = "Verifica se usuário e grupo existem antes de criar a associação"
+)]
 pub async fn create_user_group(
     State(service): State<Arc<UserGroupService>>,
     Json(payload): Json<CreateUserGroupRequest>,
@@ -58,6 +73,18 @@ pub async fn delete_user_group(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/user-groups/{id}",
+    params(("id" = String, Path, description = "Identificador da relação")),
+    responses(
+        (status = 200, description = "Relação encontrada", body = UserGroupResponse),
+        (status = 404, description = "Relação não encontrada")
+    ),
+    tag = "UserGroups",
+    summary = "Buscar relação por id",
+    description = "Retorna a associação usuário-grupo"
+)]
 pub async fn get_user_group_by_id(
     State(service): State<Arc<UserGroupService>>,
     Path(id): Path<String>,
@@ -66,6 +93,17 @@ pub async fn get_user_group_by_id(
     Ok(Json(UserGroupResponse::from(user_group)))
 }
 
+#[utoipa::path(
+    get,
+    path = "/user-groups/user/{user_id}",
+    params(("user_id" = String, Path, description = "Id do usuário")),
+    responses(
+        (status = 200, description = "Relações do usuário", body = [UserGroupResponse])
+    ),
+    tag = "UserGroups",
+    summary = "Listar por usuário",
+    description = "Recupera associações de um usuário"
+)]
 pub async fn get_user_group_by_user_id(
     State(service): State<Arc<UserGroupService>>,
     Path(user_id): Path<String>,
@@ -74,6 +112,17 @@ pub async fn get_user_group_by_user_id(
     Ok(Json(user_groups.into_iter().map(UserGroupResponse::from).collect()))
 }
 
+#[utoipa::path(
+    get,
+    path = "/user-groups/group/{group_id}",
+    params(("group_id" = String, Path, description = "Id do grupo")),
+    responses(
+        (status = 200, description = "Relações do grupo", body = [UserGroupResponse])
+    ),
+    tag = "UserGroups",
+    summary = "Listar por grupo",
+    description = "Recupera associações de um grupo"
+)]
 pub async fn get_user_group_by_group_id(
     State(service): State<Arc<UserGroupService>>,
     Path(group_id): Path<String>,
@@ -82,6 +131,14 @@ pub async fn get_user_group_by_group_id(
     Ok(Json(user_groups.into_iter().map(UserGroupResponse::from).collect()))
 }
 
+#[utoipa::path(
+    get,
+    path = "/user-groups/all",
+    responses((status = 200, description = "Lista de todas as associações", body = [UserGroupResponse])),
+    tag = "UserGroups",
+    summary = "Listar todas as relações",
+    description = "Retorna todas as ligações usuário-grupo"
+)]
 pub async fn get_all_user_groups(State(service): State<Arc<UserGroupService>>) -> Result<Json<Vec<UserGroupResponse>>, String> {
     let user_groups = service.get_all_user_groups().map_err(|e| e.to_string())?;
     Ok(Json(user_groups.into_iter().map(UserGroupResponse::from).collect()))


### PR DESCRIPTION
## Summary
- add `utoipa`, `utoipa-swagger-ui` and `serde_json` dependencies
- expose API documentation via Swagger UI under `/swagger`
- document business rules and endpoints using utoipa macros
- provide example response for user-group association
- add GitHub Pages documentation under `docs/`

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684029702c9083299348d4dc7f5837fa