### PR TITLE
Add ApiError and update handlers

### DIFF
--- a/src/adapters/api/error.rs
+++ b/src/adapters/api/error.rs
@@ -1,0 +1,72 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+#[derive(Debug)]
+pub struct ApiError {
+    pub status: StatusCode,
+    pub message: String,
+}
+
+impl ApiError {
+    pub fn new(status: StatusCode, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            message: message.into(),
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = Json(ErrorResponse {
+            error: self.message,
+        });
+        (self.status, body).into_response()
+    }
+}
+
+use crate::ports::database::DatabaseError;
+
+impl From<DatabaseError> for ApiError {
+    fn from(err: DatabaseError) -> Self {
+        match err {
+            DatabaseError::ConnectionError
+            | DatabaseError::WriteLockError
+            | DatabaseError::ReadLockError => {
+                ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+            }
+            DatabaseError::UserNotFound | DatabaseError::NotFoundError => {
+                ApiError::new(StatusCode::NOT_FOUND, err.to_string())
+            }
+            DatabaseError::UserAlreadyExists => {
+                ApiError::new(StatusCode::CONFLICT, err.to_string())
+            }
+        }
+    }
+}
+
+impl From<&'static str> for ApiError {
+    fn from(err: &'static str) -> Self {
+        ApiError::new(StatusCode::BAD_REQUEST, err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_user_not_found() {
+        let api: ApiError = DatabaseError::UserNotFound.into();
+        assert_eq!(api.status, StatusCode::NOT_FOUND);
+    }
+}

--- a/src/adapters/api/handlers.rs
+++ b/src/adapters/api/handlers.rs
@@ -7,6 +7,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+use super::error::ApiError;
 use crate::domain::models::user_model::User;
 use crate::domain::services::user_service::UserService;
 
@@ -36,26 +37,26 @@ impl From<User> for UserResponse {
 pub async fn create_user(
     State(service): State<Arc<dyn UserService>>,
     Json(payload): Json<CreateUserRequest>,
-) -> Result<Json<UserResponse>, String> {
-    let user = User::new(&payload.name, &payload.email).map_err(|e| e.to_string())?;
+) -> Result<Json<UserResponse>, ApiError> {
+    let user = User::new(&payload.name, &payload.email).map_err(ApiError::from)?;
     match service.create_user(user) {
         Ok(created_user) => Ok(Json(UserResponse::from(created_user))),
-        Err(e) => Err(e.to_string()),
+        Err(e) => Err(e.into()),
     }
 }
 
 pub async fn get_user(
     State(service): State<Arc<dyn UserService>>,
     Path(id): Path<String>,
-) -> Result<Json<UserResponse>, String> {
-    let user = service.get_user_by_id(id).map_err(|e| e.to_string())?;
+) -> Result<Json<UserResponse>, ApiError> {
+    let user = service.get_user_by_id(id).map_err(ApiError::from)?;
     Ok(Json(UserResponse::from(user)))
 }
 
 pub async fn get_all_users(
     State(service): State<Arc<dyn UserService>>,
-) -> Result<Json<Vec<UserResponse>>, String> {
-    let users = service.get_all_users().map_err(|e| e.to_string())?;
+) -> Result<Json<Vec<UserResponse>>, ApiError> {
+    let users = service.get_all_users().map_err(ApiError::from)?;
     Ok(Json(users.into_iter().map(UserResponse::from).collect()))
 }
 

--- a/src/adapters/api/mod.rs
+++ b/src/adapters/api/mod.rs
@@ -1,1 +1,2 @@
+pub mod error;
 pub mod handlers;


### PR DESCRIPTION
## Summary
- implement `ApiError` with `IntoResponse`
- map `DatabaseError` to HTTP status codes
- switch API handlers to return `ApiError`
- export new module and add tests

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings -A dead_code`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6848d4726f908329b0355b33eafac399