### PR TITLE
Implement Error for DatabaseError and improve API errors

### DIFF
--- a/src/adapters/api/error.rs
+++ b/src/adapters/api/error.rs
@@ -1,0 +1,66 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+use crate::ports::database::DatabaseError;
+
+#[derive(Debug)]
+pub enum ApiError {
+    Database(DatabaseError),
+    Validation(String),
+}
+
+impl From<DatabaseError> for ApiError {
+    fn from(err: DatabaseError) -> Self {
+        ApiError::Database(err)
+    }
+}
+
+impl From<&'static str> for ApiError {
+    fn from(err: &'static str) -> Self {
+        ApiError::Validation(err.to_string())
+    }
+}
+
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApiError::Database(e) => write!(f, "{}", e),
+            ApiError::Validation(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl std::error::Error for ApiError {}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        match self {
+            ApiError::Database(db_err) => {
+                let status = match db_err {
+                    DatabaseError::UserNotFound | DatabaseError::NotFoundError => {
+                        StatusCode::NOT_FOUND
+                    }
+                    DatabaseError::UserAlreadyExists => StatusCode::CONFLICT,
+                    DatabaseError::ConnectionError
+                    | DatabaseError::WriteLockError
+                    | DatabaseError::ReadLockError => StatusCode::INTERNAL_SERVER_ERROR,
+                };
+                (status, db_err.to_string()).into_response()
+            }
+            ApiError::Validation(msg) => (StatusCode::BAD_REQUEST, msg).into_response(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn database_error_maps_to_status_code() {
+        let err = ApiError::from(DatabaseError::UserAlreadyExists);
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+}

--- a/src/adapters/api/handlers.rs
+++ b/src/adapters/api/handlers.rs
@@ -7,6 +7,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+use super::error::ApiError;
 use crate::domain::models::user_model::User;
 use crate::domain::services::user_service::UserService;
 
@@ -36,26 +37,26 @@ impl From<User> for UserResponse {
 pub async fn create_user(
     State(service): State<Arc<dyn UserService>>,
     Json(payload): Json<CreateUserRequest>,
-) -> Result<Json<UserResponse>, String> {
-    let user = User::new(&payload.name, &payload.email).map_err(|e| e.to_string())?;
+) -> Result<Json<UserResponse>, ApiError> {
+    let user = User::new(&payload.name, &payload.email).map_err(ApiError::from)?;
     match service.create_user(user) {
         Ok(created_user) => Ok(Json(UserResponse::from(created_user))),
-        Err(e) => Err(e.to_string()),
+        Err(e) => Err(ApiError::from(e)),
     }
 }
 
 pub async fn get_user(
     State(service): State<Arc<dyn UserService>>,
     Path(id): Path<String>,
-) -> Result<Json<UserResponse>, String> {
-    let user = service.get_user_by_id(id).map_err(|e| e.to_string())?;
+) -> Result<Json<UserResponse>, ApiError> {
+    let user = service.get_user_by_id(id).map_err(ApiError::from)?;
     Ok(Json(UserResponse::from(user)))
 }
 
 pub async fn get_all_users(
     State(service): State<Arc<dyn UserService>>,
-) -> Result<Json<Vec<UserResponse>>, String> {
-    let users = service.get_all_users().map_err(|e| e.to_string())?;
+) -> Result<Json<Vec<UserResponse>>, ApiError> {
+    let users = service.get_all_users().map_err(ApiError::from)?;
     Ok(Json(users.into_iter().map(UserResponse::from).collect()))
 }
 

--- a/src/adapters/api/mod.rs
+++ b/src/adapters/api/mod.rs
@@ -1,1 +1,2 @@
 pub mod handlers;
+mod error;

--- a/src/ports/database/mod.rs
+++ b/src/ports/database/mod.rs
@@ -24,3 +24,5 @@ impl std::fmt::Display for DatabaseError {
         }
     }
 }
+
+impl std::error::Error for DatabaseError {}


### PR DESCRIPTION
## Summary
- implement `std::error::Error` for `DatabaseError`
- add new `ApiError` type for the HTTP layer
- return `ApiError` from API handlers
- map database errors to HTTP status codes
- test new error mapping

## Testing
- `cargo clippy`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6848d47865048329b1afe8817b0fa342